### PR TITLE
Jw add class popup

### DIFF
--- a/src/components/CourseDisplay.vue
+++ b/src/components/CourseDisplay.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref } from "vue";
+import ViewPopup from "./ViewPopup.vue";
 
 const props = defineProps(["course"]);
 const showViewPopup = ref(false);
@@ -16,6 +17,11 @@ const handleClick = () => {
         <h1>{{ props.course.name }}</h1>
         <p>Level: {{ props.course.level }} Hour: {{ props.course.hours }}</p>
     </div>
+    
+    <ViewPopup
+        v-model:show="showViewPopup"
+        :course="props.course"
+    />
 </template>
 
 <style scoped>

--- a/src/components/ViewPopup.vue
+++ b/src/components/ViewPopup.vue
@@ -19,30 +19,53 @@ const closeDialog = () => {
     emit('update:show', false);
 };
 
+const editClass = () => {
+    // Edit functionality would go here
+    console.log('Edit course:', props.course);
+    closeDialog();
+};
 </script>
 
 <template>
     <div>
         <div v-if="showDialog" class="modal-overlay" @click.self="closeDialog">
             <div class="modal">
-                <h3>View</h3>
-                <label for="courseName">Course Name</label>
-                <div class="field-display">{{ course.name || 'N/A' }}</div>
-                <label for="courseDepartment">Course Department</label>
-                <div class="field-display">{{ course.department || 'N/A' }}</div>
-                <label for="courseNumber">Course Number</label>
-                <div class="field-display">{{ course.courseNumber || 'N/A' }}</div>
-                <label for="creditHours">Credit Hours</label>
-                <div class="field-display">{{ course.hours || 'N/A' }}</div>
-                <label for="level">Level</label>
-                <div class="field-display">{{ course.level || 'N/A' }}</div>
-                <label for="description">Description</label>
-                <div class="field-display">{{ course.description || 'N/A' }}</div>
-                <div class="buttons">
-                    <DeleteCourseButton :course="course.courseNumber" />
-                </div>
+                <h3>View Course</h3>
+                <v-text-field
+                    :model-value="course.name || 'N/A'"
+                    label="Course Name"
+                    readonly
+                />
+                <v-text-field
+                    :model-value="course.department || 'N/A'"
+                    label="Department"
+                    readonly
+                />
+                <v-text-field
+                    :model-value="course.courseNumber || 'N/A'"
+                    label="Course Number"
+                    readonly
+                />
+                <v-text-field
+                    :model-value="course.hours || 'N/A'"
+                    label="Credit Hours"
+                    readonly
+                />
+                <v-text-field
+                    :model-value="course.level || 'N/A'"
+                    label="Level"
+                    readonly
+                />
+                <v-text-field
+                    :model-value="course.description || 'N/A'"
+                    label="Description"
+                    readonly
+                />
                 <div class="buttons">
                     <EditButton :course="course.courseNumber" />
+                </div>
+                <div class="buttons">
+                    <DeleteCourseButton :course="course?.courseNumber" />
                 </div>
                 <div class="buttons">
                     <button @click="closeDialog">Close</button>
@@ -76,14 +99,5 @@ const closeDialog = () => {
 .buttons {
     margin-top: 1rem;
     text-align: right;
-}
-.field-display {
-    background: antiquewhite;
-    color: black;
-    border: 5px solid black;
-    display: block;
-    padding: 0.5rem;
-    margin-bottom: 0.5rem;
-    border-radius: 3px;
 }
 </style>

--- a/src/components/ViewPopup.vue
+++ b/src/components/ViewPopup.vue
@@ -1,8 +1,9 @@
 
 
 <script setup>
-import { ref, watch } from "vue";
+import { toRef } from "vue";
 import DeleteCourseButton from "./DeleteCourseButton.vue";
+//import EditButton from "./EditButton.vue";
 import courseServices from "../services/courseServices.js";
 
 const props = defineProps({
@@ -12,40 +13,39 @@ const props = defineProps({
 
 const emit = defineEmits(['update:show']);
 
-const showDialog = ref(false);
-
-// Watch for changes to the show prop
-watch(() => props.show, (newVal) => {
-    showDialog.value = newVal;
-});
+const showDialog = toRef(props, "show");
 
 const closeDialog = () => {
-    showDialog.value = false;
     emit('update:show', false);
 };
 
-const editClass = () => {
-    // Edit functionality would go here
-    console.log('Edit course:', props.course);
-    closeDialog();
-};
 </script>
 
 <template>
     <div>
         <div v-if="showDialog" class="modal-overlay" @click.self="closeDialog">
             <div class="modal">
-                <h3>Course Details</h3>
-                <p><strong>Course Name:</strong> {{ course?.name || 'N/A' }}</p>
-                <p><strong>Course Department:</strong> {{ course?.department || 'N/A' }}</p>
-                <p><strong>Course Number:</strong> {{ course?.courseNumber || 'N/A' }}</p>
-                <p><strong>Credit Hours:</strong> {{ course?.hours || 'N/A' }}</p>
-                <p><strong>Level:</strong> {{ course?.level || 'N/A' }}</p>
-                <p><strong>Description:</strong> {{ course?.description || 'N/A' }}</p>
+                <h3>View</h3>
+                <label for="courseName">Course Name</label>
+                <div class="field-display">{{ course.name || 'N/A' }}</div>
+                <label for="courseDepartment">Course Department</label>
+                <div class="field-display">{{ course.department || 'N/A' }}</div>
+                <label for="courseNumber">Course Number</label>
+                <div class="field-display">{{ course.courseNumber || 'N/A' }}</div>
+                <label for="creditHours">Credit Hours</label>
+                <div class="field-display">{{ course.hours || 'N/A' }}</div>
+                <label for="level">Level</label>
+                <div class="field-display">{{ course.level || 'N/A' }}</div>
+                <label for="description">Description</label>
+                <div class="field-display">{{ course.description || 'N/A' }}</div>
+                <div class="buttons">
+                    <DeleteCourseButton :course="course.courseNumber" />
+                </div>
+                <div class="buttons">
+                    <EditButton :course="course.courseNumber" />
+                </div>
                 <div class="buttons">
                     <button @click="closeDialog">Close</button>
-                    <DeleteCourseButton :course="course.courseNumber" />
-                    <button @click="editClass">Edit</button>
                 </div>
             </div>
         </div>
@@ -59,51 +59,31 @@ const editClass = () => {
     left: 0;
     right: 0;
     bottom: 0;
-    background: rgba(0, 0, 0, 0.5);
+    background-color: rgba(0, 0, 0, 0.5);
     display: flex;
     justify-content: center;
     align-items: center;
-    z-index: 1000;
 }
-
 .modal {
-    background: white;
-    padding: 2rem;
-    border-radius: 8px;
-    max-width: 500px;
-    width: 90%;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+    background: black;
+    padding: 1.5rem;
+    border-radius: 5px;
+    width: 80%;
+    color: white;
+    max-height: 80%;
+    overflow-y: auto;
 }
-
-.modal h3 {
-    margin-top: 0;
-    margin-bottom: 1rem;
-    color: #333;
-}
-
-.modal p {
-    margin: 0.5rem 0;
-    line-height: 1.5;
-}
-
 .buttons {
-    display: flex;
-    gap: 0.5rem;
-    justify-content: flex-end;
-    margin-top: 1.5rem;
-    padding-top: 1rem;
-    border-top: 1px solid #eee;
+    margin-top: 1rem;
+    text-align: right;
 }
-
-.buttons button {
-    padding: 0.5rem 1rem;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    cursor: pointer;
-    background: white;
-}
-
-.buttons button:hover {
-    background: #f5f5f5;
+.field-display {
+    background: antiquewhite;
+    color: black;
+    border: 5px solid black;
+    display: block;
+    padding: 0.5rem;
+    margin-bottom: 0.5rem;
+    border-radius: 3px;
 }
 </style>

--- a/src/components/ViewPopup.vue
+++ b/src/components/ViewPopup.vue
@@ -1,0 +1,109 @@
+
+
+<script setup>
+import { ref, watch } from "vue";
+import DeleteCourseButton from "./DeleteCourseButton.vue";
+import courseServices from "../services/courseServices.js";
+
+const props = defineProps({
+    show: Boolean,
+    course: Object,
+});
+
+const emit = defineEmits(['update:show']);
+
+const showDialog = ref(false);
+
+// Watch for changes to the show prop
+watch(() => props.show, (newVal) => {
+    showDialog.value = newVal;
+});
+
+const closeDialog = () => {
+    showDialog.value = false;
+    emit('update:show', false);
+};
+
+const editClass = () => {
+    // Edit functionality would go here
+    console.log('Edit course:', props.course);
+    closeDialog();
+};
+</script>
+
+<template>
+    <div>
+        <div v-if="showDialog" class="modal-overlay" @click.self="closeDialog">
+            <div class="modal">
+                <h3>Course Details</h3>
+                <p><strong>Course Name:</strong> {{ course?.name || 'N/A' }}</p>
+                <p><strong>Course Department:</strong> {{ course?.department || 'N/A' }}</p>
+                <p><strong>Course Number:</strong> {{ course?.courseNumber || 'N/A' }}</p>
+                <p><strong>Credit Hours:</strong> {{ course?.hours || 'N/A' }}</p>
+                <p><strong>Level:</strong> {{ course?.level || 'N/A' }}</p>
+                <p><strong>Description:</strong> {{ course?.description || 'N/A' }}</p>
+                <div class="buttons">
+                    <button @click="closeDialog">Close</button>
+                    <DeleteCourseButton :course="course.courseNumber" />
+                    <button @click="editClass">Edit</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<style scoped>
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.modal {
+    background: white;
+    padding: 2rem;
+    border-radius: 8px;
+    max-width: 500px;
+    width: 90%;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+.modal h3 {
+    margin-top: 0;
+    margin-bottom: 1rem;
+    color: #333;
+}
+
+.modal p {
+    margin: 0.5rem 0;
+    line-height: 1.5;
+}
+
+.buttons {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
+    margin-top: 1.5rem;
+    padding-top: 1rem;
+    border-top: 1px solid #eee;
+}
+
+.buttons button {
+    padding: 0.5rem 1rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    cursor: pointer;
+    background: white;
+}
+
+.buttons button:hover {
+    background: #f5f5f5;
+}
+</style>


### PR DESCRIPTION
Add the class popup from the list elements.
Uses some strange styling but we'll worry about that later when we look at css a bit closer.
@Maximus253 whenever you get the edit screen finished, go into ViewPopup.vue and uncomment the edit button import at the top of the file. This should add back the edit button, which is currently not present.